### PR TITLE
Better support for related fields & live fetching of field labels/type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# public
+# Enhanced Datatable
 Generic components
 
 Currently there are 2 generic components (PFB). Very soon I will add DEMO components which will show how to use them.
 
 1. datatable: Generic datatable which uses standard lightning-datatable for showing records in table <br/>
      1. Gets data from database automatically. Can use relationship fields also. <br/>
-     2. Sort functionality (including related fields) <br/>
-     3. Pagination - first, previous, next and last pages <br/>
-     4. Persistant selection of records across pages. getSelectedRows public method to get selected data. <br/>
-     5. All events of lightning-datatable plus event while loading data <br/>
-     6. Cacheable data <br/>
-     7. Sosl search <br/>
-     8. Dynamically change data filters <br/>
+     2. Automatically gets existing sObject field labels (allows for custom labels; includes related fields) <br/>
+     3. Sort functionality (including related fields) <br/>
+     4. Pagination - first, previous, next and last pages <br/>
+     5. Persistant selection of records across pages. getSelectedRows public method to get selected data. <br/>
+     6. All events of lightning-datatable plus event while loading data <br/>
+     7. Cacheable data <br/>
+     8. Sosl search <br/>
+     9. Dynamically change data filters <br/>
 
 2. upload: Currently implemented only for admins (without shareable)  <br/>
     1. Use component in create form wherein, the file has to be uploaded before record (like account or case etc) is created. <br/>
@@ -19,5 +20,3 @@ Currently there are 2 generic components (PFB). Very soon I will add DEMO compon
     3. Search for files <br/>
     4. Delete files <br/>
     5. Used datatable for showing records which gives all the functionality like sort, pagination etc <br/>
-    
-     

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Currently there are 2 generic components (PFB). Very soon I will add DEMO compon
 
 1. datatable: Generic datatable which uses standard lightning-datatable for showing records in table <br/>
      1. Gets data from database automatically. Can use relationship fields also. <br/>
+     * This fork adds support for sorting by related fields <br/>
      2. Sort functionality <br/>
      3. Pagination - first, previous, next and last pages <br/>
      4. Persistant selection of records across pages. getSelectedRows public method to get selected data. <br/>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Currently there are 2 generic components (PFB). Very soon I will add DEMO compon
 
 1. datatable: Generic datatable which uses standard lightning-datatable for showing records in table <br/>
      1. Gets data from database automatically. Can use relationship fields also. <br/>
-     * This fork adds support for sorting by related fields <br/>
-     2. Sort functionality <br/>
+     2. Sort functionality (including related fields) <br/>
      3. Pagination - first, previous, next and last pages <br/>
      4. Persistant selection of records across pages. getSelectedRows public method to get selected data. <br/>
      5. All events of lightning-datatable plus event while loading data <br/>

--- a/src/classes/datatableController.cls
+++ b/src/classes/datatableController.cls
@@ -12,7 +12,7 @@
  * 1.0    8/1/2019, 1:50:15 PM   Sasank Subrahmanyam V     Initial Version
  * Alon Waisman, 2/27/2023: Added support for fetching field labels and type (so they don't need to be added in the table config)
 **/
-public with sharing class Datatable_LWC_Controller {
+public with sharing class datatableController {
 
     @AuraEnabled(Cacheable=true)
     public static Map<String, Map<String, String>> fieldInfo(String objectName, String[] fieldNames){

--- a/src/classes/datatableController.cls
+++ b/src/classes/datatableController.cls
@@ -1,17 +1,71 @@
 /**
  * @File Name          : datatableController.cls
- * @Description        : 
+ * @Description        :
  * @Author             : Sasank Subrahmanyam V
- * @Group              : 
+ * @Group              :
  * @Last Modified By   : Sasank Subrahmanyam V
  * @Last Modified On   : 8/4/2019, 10:17:06 AM
- * @Modification Log   : 
+ * @Modification Log   :
  *==============================================================================
  * Ver         Date                     Author      		      Modification
  *==============================================================================
  * 1.0    8/1/2019, 1:50:15 PM   Sasank Subrahmanyam V     Initial Version
+ * Alon Waisman, 2/27/2023: Added support for fetching field labels and type (so they don't need to be added in the table config)
 **/
-public with sharing class datatableController {
+public with sharing class Datatable_LWC_Controller {
+
+    @AuraEnabled(Cacheable=true)
+    public static Map<String, Map<String, String>> fieldInfo(String objectName, String[] fieldNames){
+        try {
+            Map<String, Map<String, String>> fieldInfoByAPIName = new Map<String, Map<String, String>>();
+
+            Map<String, String> specialDatatableTypesByDisplayType = new Map<String, String>{
+                'boolean'  => 'boolean',
+                'currency' => 'currency',
+                'date'     => 'date-local',
+                'datetime' => 'date',
+                'double'   => 'number',
+                'email'    => 'email',
+                'integer'  => 'number',
+                'location' => 'location',
+                'long'     => 'number',
+                'percent'  => 'percent',
+                'phone'    => 'phone',
+                'time'     => 'date',
+                'url'      => 'url'
+            };
+
+            Schema.SObjectType sobjectType = ((SObject)Type.forName('', objectName).newInstance()).getSObjectType();
+
+            for (String fieldName : fieldNames) {
+                Schema.DescribeFieldResult description = fieldDescription(sobjectType, fieldName);
+                String datatableType = specialDatatableTypesByDisplayType.get(String.valueOf(description.getType()).toLowerCase());
+
+                fieldInfoByAPIName.put(fieldName,
+                    new Map<String, String>{'label' => description.getLabel(), 'type' => datatableType != null ? datatableType : 'string'}
+                );
+            }
+
+            return fieldInfoByAPIName;
+        }
+         catch (Exception e) {
+            throw new AuraHandledException(e.getMessage());
+        }
+    }
+        private static Schema.DescribeFieldResult fieldDescription(Schema.SObjectType sobjectType, String fieldName) {
+            Map<String, Schema.SObjectField> fieldsByName = sobjectType.getDescribe().fields.getMap();
+
+            if (fieldName.contains('.')) {
+                String relationship = fieldName.split('\\.')[0];
+                fieldName = fieldName.removeStart(relationship + '.');
+                relationship = relationship.endsWith('__r') ? relationship.replace('__r', '__c') : relationship + 'Id';
+                Schema.SObjectType parentSobjectType = fieldsByName.get(relationship).getDescribe().getReferenceTo()[0];
+                return fieldDescription(parentSobjectType, fieldName);
+            } else {
+                return fieldsByName.get(fieldName).getDescribe();
+            }
+        }
+
 
     @AuraEnabled(Cacheable=true)
     public static Map<String, Object> fetchDataMapCached(Map<String, Object> params) {
@@ -20,7 +74,6 @@ public with sharing class datatableController {
 
     @AuraEnabled
     public static Map<String, Object> fetchDataMap(Map<String, Object> params) {
-
         String objectName = params.containsKey('objectName') ? (String)params.get('objectName') : null;
         String fields = params.containsKey('fields') ? (String)params.get('fields') : null;
         String queryFilters = params.containsKey('queryFilters') ? (String)params.get('queryFilters') : null;
@@ -29,14 +82,14 @@ public with sharing class datatableController {
         String soslSearchTerm = params.containsKey('soslSearchTerm') ? (String)params.get('soslSearchTerm') : null;
         Boolean sortAsc = params.containsKey('sortAsc') ? (Boolean)params.get('sortAsc') : false;
         Integer limitRecords = params.containsKey('limitRecords') ? Integer.valueOf(params.get('limitRecords')) : null;
-        
+
         try{
             //Initial checks
             String limitRecordsStr = String.valueOf(Integer.valueOf(limitRecords));
-            
+
             //Declare query string
             String query;
-            
+
             //Query initialization for Soql and Sosl
             if(queryType == 'SOQL'){
                 query = 'SELECT Id, ' + fields + ' FROM ' + objectName;
@@ -49,16 +102,16 @@ public with sharing class datatableController {
             if(String.isNotBlank(queryFilters)){
                 query += ' WHERE ' + queryFilters;
             }
-            
+
             //Adding order by and limit records
             if(String.isNotBlank(sortBy) && queryType == 'SOQL'){
                 query += ' ORDER BY ' + sortBy + (sortAsc?' ASC ':' DESC ');
             }
-            
+
             if(String.isNotBlank(limitRecordsStr)) {
                 query += ' LIMIT ' + limitRecordsStr;
             }
-            
+
             //Log the query before getting query results from database
             Map<String, Object> returnMap = new Map<String, Object>();
             List<sObject> sObjectsList = new List<sObject>();
@@ -73,16 +126,16 @@ public with sharing class datatableController {
             }
 
             returnMap.put('records', sObjectsList);
-            
+
             //Log the result
             system.debug('returnMap => '+returnMap);
-            
-            return returnMap;     
+
+            return returnMap;
         }
         catch(Exception ex) {
             system.debug('Error => '+ex.getMessage());
             throw new AuraHandledException(ex.getMessage());
-        }   
+        }
     }
 
 }

--- a/src/classes/datatableController.cls
+++ b/src/classes/datatableController.cls
@@ -11,6 +11,7 @@
  *==============================================================================
  * 1.0    8/1/2019, 1:50:15 PM   Sasank Subrahmanyam V     Initial Version
  * Alon Waisman, 2/27/2023: Added support for fetching field labels and type (so they don't need to be added in the table config)
+ * Alon Waisman, 3/27/2024: Simplified a few lines in fetchDataMap and removed 'Id' from the SOQL query to avoid an error when the user includes it in the provided list of fields
 **/
 public with sharing class datatableController {
 
@@ -74,14 +75,14 @@ public with sharing class datatableController {
 
     @AuraEnabled
     public static Map<String, Object> fetchDataMap(Map<String, Object> params) {
-        String objectName = params.containsKey('objectName') ? (String)params.get('objectName') : null;
-        String fields = params.containsKey('fields') ? (String)params.get('fields') : null;
-        String queryFilters = params.containsKey('queryFilters') ? (String)params.get('queryFilters') : null;
-        String sortBy = params.containsKey('sortBy') ? (String)params.get('sortBy') : null;
-        String queryType = params.containsKey('queryType') ? (String)params.get('queryType') : null;
-        String soslSearchTerm = params.containsKey('soslSearchTerm') ? (String)params.get('soslSearchTerm') : null;
-        Boolean sortAsc = params.containsKey('sortAsc') ? (Boolean)params.get('sortAsc') : false;
-        Integer limitRecords = params.containsKey('limitRecords') ? Integer.valueOf(params.get('limitRecords')) : null;
+        String objectName     = (String)params.get('objectName');
+        String fields         = (String)params.get('fields');
+        String queryFilters   = (String)params.get('queryFilters');
+        String sortBy         = (String)params.get('sortBy');
+        String queryType      = (String)params.get('queryType');
+        String soslSearchTerm = (String)params.get('soslSearchTerm');
+        Boolean sortAsc       = (Boolean)params.get('sortAsc') ?? false;
+        Integer limitRecords  = Integer.valueOf(params.get('limitRecords'));
 
         try{
             //Initial checks
@@ -92,7 +93,7 @@ public with sharing class datatableController {
 
             //Query initialization for Soql and Sosl
             if(queryType == 'SOQL'){
-                query = 'SELECT Id, ' + fields + ' FROM ' + objectName;
+                query = 'SELECT ' + fields + ' FROM ' + objectName;
             }
             else if(queryType == 'SOSL') {
                 query = 'Id, ' + fields;

--- a/src/lwc/datatable/datatable.js
+++ b/src/lwc/datatable/datatable.js
@@ -13,8 +13,8 @@
  * 1.0    8/1/2019, 11:08:28 AM   Sasank Subrahmanyam V     Initial Version
 **/
 import { LightningElement, api, track } from 'lwc';
-import fetchDataMap from '@salesforce/apex/Datatable_LWC_Controller.fetchDataMap';
-import fetchDataMapCached from '@salesforce/apex/Datatable_LWC_Controller.fetchDataMapCached';
+import fetchDataMap from '@salesforce/apex/datatableController.fetchDataMap';
+import fetchDataMapCached from '@salesforce/apex/datatableController.fetchDataMapCached';
 
 export default class Datatable extends LightningElement {
     // this will have all the configuration for table

--- a/src/lwc/datatable/datatable.js
+++ b/src/lwc/datatable/datatable.js
@@ -14,9 +14,9 @@
  * Alon Waisman, 2/27/2023: Added support for live fetching of field labels and type (so they don't need to be added in the table config)
 **/
 import { LightningElement, api, track } from 'lwc';
-import fetchDataMap       from '@salesforce/apex/Datatable_LWC_Controller.fetchDataMap';
-import fetchDataMapCached from '@salesforce/apex/Datatable_LWC_Controller.fetchDataMapCached';
-import getFieldInfo       from '@salesforce/apex/Datatable_LWC_Controller.fieldInfo';
+import fetchDataMap       from '@salesforce/apex/datatableController.fetchDataMap';
+import fetchDataMapCached from '@salesforce/apex/datatableController.fetchDataMapCached';
+import getFieldInfo       from '@salesforce/apex/datatableController.fieldInfo';
 
 export default class Datatable extends LightningElement {
     // this will have all the configuration for table


### PR DESCRIPTION
1. Added support for sorting when related fields are used
2. Automatically applies current SObject field labels and types when provided the "api" property in the columns config. Still allows use of a custom label or type if that's preferred.
- Example columns config:
columns: [
    { sortable: true, api: 'Name' },
    { sortable: true, api: 'CreatedBy.Name', label: 'Creator Name' },
    { sortable: true, api: 'Custom_Lookup__r.CreatedBy.Other_Custom_Lookup__r.CreatedDate' },
]

- ... yields the following:
columns: [
    { sortable: true, api: 'Name', label: 'SObject Name', type: 'string' },
    { sortable: true, api: 'CreatedBy.Name', label: 'Creator Name', fieldName: 'CreatedBy.Name', type: 'string'},
    { sortable: true, api: 'Custom_Lookup__r.CreatedBy.Other_Custom_Lookup__r.CreatedDate', label: 'Created Date', type: 'date' },
]
